### PR TITLE
feat: support `v` prefix in CLI GH release name

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ardunno-cli-gen",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ardunno-cli-gen",
-      "version": "0.1.5",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "commander": "^10.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ardunno-cli-gen",
-  "version": "0.1.5",
+  "version": "0.1.7",
   "description": "Generates nice-grpc API for the Arduino CLI",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
From Arduino CLI `>=0.35.0-rc.1`, the `v` prefix is expected in the GitHub release name.

Ref: arduino/arduino-cli#2374